### PR TITLE
Modify StreamPipes link to Apache Github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 
 - [sensorbee](https://github.com/sensorbee/sensorbee) [Go] - lightweight stream processing engine for IoT.
 - [Apache Edgent](https://github.com/apache/incubator-edgent) [Java] - a programming model and runtime that enables continuous streaming analytics on gateways and edge devices which can work with centralized systems to provide efficient and timely analytics across the whole IoT ecosystem: from the center to the edge, opens sourced by IBM.
-- [StreamPipes](https://github.com/streampipes/streampipes) [Java] - a complete toolbox to easily analyze IoT (big) data streams without programming skills.
+- [Apache StreamPipes](https://github.com/apache/incubator-streampipes) [Java] - a self-service (Industrial) IoT toolbox to enable non-technical users to connect, analyze and explore IoT data streams.
 
 ### DSL
 


### PR DESCRIPTION
This PR updates the link of the StreamPipes Github repository to the new Github repository hosted at the ASF, after StreamPipes has joined the Apache Incubator.

I also changed the project description to the new one-line description (taken from streampipes.apache.org)

Thanks for mentioning StreamPipes here!