### PR TITLE
Add Materialize.com to Streaming SQL section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [squall](https://github.com/epfldata/squall) [Java] - Squall executes SQL queries on top of Storm for doing online processing.
 - [StreamCQL](https://github.com/Zhiqiang-He/StreamCQL) [Java] - Continuous Query Language on RealTime Computation System.
 - [ksqlDB](https://github.com/confluentinc/ksql) [Java] - : A cloud-native, source-available [database](https://ksqldb.io/) purpose-built for stream processing applications
+- [Materialize](https://materialize.com) [Rust] - A source-available streaming SQL engine for maintaining materialized views on data from message brokers and databases.
 
 
 ### Benchmark


### PR DESCRIPTION
[Materialize](https://materialize.com/docs) is a new-ish product that fits in a couple categories here, but I think it makes the most sense in "Streaming SQL" category.

Full disclosure: I work for Materialize!