### PR TITLE
Add Apache Ballista

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 ### Streaming Engine
 
 - [Apache Apex](https://github.com/apache/apex-core) [Java] - unified platform for big data stream and batch processing.
+- [Apache Ballista](https://github.com/apache/arrow/tree/master/rust/ballista) [Rust] - distributed compute platform powered by Apache Arrow.
 - [Apache Flink](https://github.com/apache/flink) [Java] - system for high-throughput, low-latency data stream processing that supports stateful computation, data-driven windowing semantics and iterative stream processing.
 - [Apache Heron (incubating)](https://github.com/apache/incubator-heron) [Java] - a realtime, distributed, fault-tolerant stream processing engine from Twitter.
 - [Apache Samza](https://github.com/apache/samza) [Scala/Java] - distributed stream processing framework that build on Kafka(messaging, storage) and YARN(fault tolerance, processor isolation, security and resource management).


### PR DESCRIPTION
Ballista is now part of Apache Arrow and would be a nice addition here. The arrow data fusion project is making steady progress at producing an analytics optimized query engine. The Ballista project is another part of the story - introducing a distributed DAG / stream processor similar to Apache Spark but based on columnar Apache Arrow formats. The project was recently accepted by Apache. More information is available here: https://ballistacompute.org/thisweek/2021/04/10/this-week-in-ballista-10/

Thanks for keeping this list - I've found it very helpful.