### PR TITLE
Add Quix Streams as a Python stream processing library for Apache Kafka 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [Benthos](https://github.com/Jeffail/benthos) [Go] - Benthos is a high performance and resilient message streaming service, able to connect various sources and sinks and perform arbitrary actions, transformations and filters on payloads
 - [FS2(prev. 'Scalaz-Stream')](https://github.com/functional-streams-for-scala/fs2) [Scala] - Compositional, streaming I/O library for Scala.
 - [monix](https://github.com/monix/monix) [Scala] - high-performance Scala / Scala.js library for composing asynchronous and event-based programs.
-- [Quix Streams](https://github.com/quixio/quix-streams) [Python] - a streaming library designed to process high volumes of time-series data with up to nanosecond precision using Apache Kafka as a message broker.
+- [Quix Streams](https://github.com/quixio/quix-streams) [Python] - a streaming library originally designed for the McLaren Formula 1 racing team that can process high volumes of time-series data with up to nanosecond precision using Apache Kafka as a message broker.
 - [Scramjet Node.js](https://github.com/scramjetorg/framework-js) - [Node.js] functional reactive stream programming framework written on top of Node.js object streams + [the legacy Scramjet.js version](https://github.com/scramjetorg/scramjet)
 - [Scramjet Python](https://github.com/scramjetorg/framework-python) - [Python] functional reactive stream programming framework written from scratch operating on object, string and buffer streams.
 - [Scramjet C++](https://github.com/scramjetorg/framework-cpp) - [C++] functional reactive stream programming framework written on top of Node.js object streams.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [Benthos](https://github.com/Jeffail/benthos) [Go] - Benthos is a high performance and resilient message streaming service, able to connect various sources and sinks and perform arbitrary actions, transformations and filters on payloads
 - [FS2(prev. 'Scalaz-Stream')](https://github.com/functional-streams-for-scala/fs2) [Scala] - Compositional, streaming I/O library for Scala.
 - [monix](https://github.com/monix/monix) [Scala] - high-performance Scala / Scala.js library for composing asynchronous and event-based programs.
-- [Quix Streams](https://github.com/quixio/quix-streams) [Python] - a high-performance streaming library designed to process high volumes of time-series data with up to nanosecond precision using Apache Kafka as a message broker.
+- [Quix Streams](https://github.com/quixio/quix-streams) [Python] - a streaming library designed to process high volumes of time-series data with up to nanosecond precision using Apache Kafka as a message broker.
 - [Scramjet Node.js](https://github.com/scramjetorg/framework-js) - [Node.js] functional reactive stream programming framework written on top of Node.js object streams + [the legacy Scramjet.js version](https://github.com/scramjetorg/scramjet)
 - [Scramjet Python](https://github.com/scramjetorg/framework-python) - [Python] functional reactive stream programming framework written from scratch operating on object, string and buffer streams.
 - [Scramjet C++](https://github.com/scramjetorg/framework-cpp) - [C++] functional reactive stream programming framework written on top of Node.js object streams.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [Benthos](https://github.com/Jeffail/benthos) [Go] - Benthos is a high performance and resilient message streaming service, able to connect various sources and sinks and perform arbitrary actions, transformations and filters on payloads
 - [FS2(prev. 'Scalaz-Stream')](https://github.com/functional-streams-for-scala/fs2) [Scala] - Compositional, streaming I/O library for Scala.
 - [monix](https://github.com/monix/monix) [Scala] - high-performance Scala / Scala.js library for composing asynchronous and event-based programs.
+- [Quix Streams](https://github.com/quixio/quix-streams) [Python] - a high-performance streaming library designed to process high volumes of time-series data with up to nanosecond precision using Apache Kafka as a message broker.
 - [Scramjet Node.js](https://github.com/scramjetorg/framework-js) - [Node.js] functional reactive stream programming framework written on top of Node.js object streams + [the legacy Scramjet.js version](https://github.com/scramjetorg/scramjet)
 - [Scramjet Python](https://github.com/scramjetorg/framework-python) - [Python] functional reactive stream programming framework written from scratch operating on object, string and buffer streams.
 - [Scramjet C++](https://github.com/scramjetorg/framework-cpp) - [C++] functional reactive stream programming framework written on top of Node.js object streams.


### PR DESCRIPTION
This is a powerful commercial library which is now being open-sourced. Was developed at F1 McLaren for processing huge sensor data streams from F1 racing cars, so useful for anyone working with sensor data or any other high-frequency time-series data,

- [https://pypi.org/project/quixstreams/](https://pypi.org/project/quixstreams/)
- [https://github.com/quixio/quix-streams](https://github.com/quixio/quix-streams)

Was originally started as a companion to the [[Quix.io](http://quix.io/)](http://quix.io/) platform, but can now be used as a standalone library with any Kafka installation.