### PR TITLE
Add javactrl-kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 
 ### Streaming Application
 
+- [javactrl-kafka](https://github.com/javactrl/javactrl-kafka) - An application of a stateful stream processing for workflow as Java code (microservices orchestration, business process automation, and more).
 - [straw](https://github.com/rwalk/straw) [Python/Java] - A platform for real-time streaming search.
 - [storm-crawler](https://github.com/DigitalPebble/storm-crawler) [Java] - Web crawler SDK based on Apache Storm.
 - [Zilla](https://github.com/aklivity/zilla) [Java] - Cross-platform, API gateway built for event-driven architectures and streaming that supports standard protocols such as HTTP, SSE, gRPC, MQTT and the native Kafka protocol.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 
 ### Streaming Application
 
-- [javactrl-kafka](https://github.com/javactrl/javactrl-kafka) - An application of a stateful stream processing for workflow as Java code (microservices orchestration, business process automation, and more).
+- [javactrl-kafka](https://github.com/javactrl/javactrl-kafka) [Java] - An application of a stateful stream processing for workflow as Java code (microservices orchestration, business process automation, and more).
 - [straw](https://github.com/rwalk/straw) [Python/Java] - A platform for real-time streaming search.
 - [storm-crawler](https://github.com/DigitalPebble/storm-crawler) [Java] - Web crawler SDK based on Apache Storm.
 - [Zilla](https://github.com/aklivity/zilla) [Java] - Cross-platform, API gateway built for event-driven architectures and streaming that supports standard protocols such as HTTP, SSE, gRPC, MQTT and the native Kafka protocol.


### PR DESCRIPTION
This is my tool displaying how stateful stream processors can be used for defining workflows as code. Basically, this is more of an approach rather than a tool, the tool is very minimalistic but depends on my delimited continuations implementation. Though just after Java (or Kotlin) gets its own persistent continuations the approach will work without any library.