### PR TITLE
Add AutoMQ to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [Apache Kafka](https://github.com/apache/kafka) [Scala/Java] - distributed, partitioned, replicated commit log service, which provides the functionality of a messaging system, but with a unique design.
 - [Apache Pulsar](https://github.com/apache/incubator-pulsar) [Java] - distributed pub-sub messaging platform with a very flexible messaging model and an intuitive client API.
 - [Apache RocketMQ](https://github.com/apache/rocketmq) [Java] - distributed messaging and streaming platform with low latency, high performance and reliability, trillion-level capacity and flexible scalability.
+- [AutoMQ](https://github.com/AutoMQ/automq) [Scala/Java] - cloud-first alternative to Kafka by decoupling durability to S3 and EBS. 100% Kafka compatible. 10x cost-effective. Autoscale in seconds. Single-digit ms latency.
 - [brooklin](https://github.com/linkedin/Brooklin/) [Java] - a distributed system intended for streaming data between various heterogeneous source and destination systems with high reliability and throughput at scale from Linkedin (replaced databus).
 - [camus](https://github.com/linkedin/camus) [Java] - Linkedin's Kafka -> HDFS pipeline.
 - [databus](https://github.com/linkedin/databus) [Java] - Linkedin's source-agnostic distributed change data capture system.


### PR DESCRIPTION
AutoMQ is a cloud-first alternative to Kafka by decoupling durability to S3 and EBS. 10x cost-effective. Autoscale in seconds. Single-digit ms latency.

Recently, AutoMQ[1] has gained a lot of love and attention from the developer community, with the number of stars soon reaching 3200+. It has also appeared on GitHub trending, both in the overall[2] and Java categories[3]. We hope to be featured on theawesome-streaming.

[1]. https://github.com/AutoMQ/automq
[2]. https://github.motakasoft.com/trending/?d=2024-07-28&l=java
[3]. https://github.motakasoft.com/trending/?d=2024-07-27&l=all