### PR TITLE
Add Kzmlabs StateFun Actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [Tributary](https://github.com/timkpaine/tributary) [Python] - A python library for constructing dataflow graphs. Supports synchronous, reactive data streams built using python generators that mimic complex event processors, as well as lazily-evaluated acyclic graphs and functional currying streams.
 - [YoMo](https://github.com/yomorun/yomo) [Go] - An open source Streaming Serverless Framework for building Low-latency Geo-distributed system. YoMo Built atop [QUIC Transport Protocol](https://en.wikipedia.org/wiki/QUIC) and Functional Reactive Programming interface. 
 - [Mediapipe](https://github.com/google/mediapipe) - Cross-platform, customizable ML solutions for live and streaming media.
+- [Kzmlabs StateFun Actors](https://github.com/kzmlabs/flink-statefun) [Java] - Stateful actors on Apache Flink 2.x with durable per-key state, exactly-once messaging, and Kafka/Kinesis I/O. Continuation of Apache Stateful Functions on Flink 2.2 + Java 21.
 
 ### Streaming Application
 


### PR DESCRIPTION
Adding Kzmlabs StateFun Actors under Streaming Library. It's a stateful actor framework on Apache Flink, fits there alongside Kafka Streams and Akka Streams.

It's a continuation of Apache Stateful Functions on the modern Flink line (Flink 2.2, Java 21). Apache StateFun stopped releasing in October 2024 at 3.4.0 / Flink 1.16; this fork picks up the same programming model and brings it forward  restored Kinesis I/O on the Flink 2.x source/sink, mandatory K8s release gate via the Flink Operator. Apache 2.0, on Maven Central + GHCR.

https://github.com/kzmlabs/flink-statefun