### PR TITLE
Add beava to Streaming Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 - [ArkFlow](https://github.com/arkflow-rs/arkflow) [Rust] - High-performance Rust stream processing engine, providing powerful data stream processing capabilities, supporting multiple input/output sources and processors.
 - [Arroyo](https://github.com/ArroyoSystems/arroyo) [Rust] - a distributed stream processing engine. Supports SQL and Rust pipelines. Scales up to millions of events per second. Supports stateful operations like windows and joins, state checkpointing for fault-tolerance and recovery of pipelines. Uses the Timely Dataflow model.
 - [AthenaX](https://github.com/uber/AthenaX) [Java] - Uber's Stream Analytics Framework used in production
+- [beava](https://github.com/beava-dev/beava) [Rust/Python] - Single-binary feature server. Push events over HTTP or TCP, query fresh per-entity counters and aggregates inline, no broker in between. For fraud, recommendations, LLM guardrails, and in-product analytics.
 - [Bytewax](https://github.com/bytewax/bytewax) [Python] - data parallel, distributed, stateful stream processing framework.
 - [CocoIndex](https://github.com/cocoindex-io/cocoindex) [Rust/Python] - ETL framework to build fresh index for AI, with realtime incremental updates.
 - [Faust](https://github.com/robinhood/faust) [Python] - stream processing library, porting the ideas from Kafka Streams to Python


### PR DESCRIPTION
Adds [beava](https://github.com/beava-dev/beava) under **Streaming Engine**, alphabetically between AthenaX and Bytewax.

beava is an Apache 2.0 single-binary feature server: push events over HTTP or TCP, query fresh per-entity counters and aggregates (counts, sums, top-k, rolling windows, quantiles) inline. The hot path is one Rust process, with a Python SDK for declaring pipelines. Built for the kinds of decisions that have to use the latest event: fraud signals, recommendation features, LLM guardrails, and in-product analytics.

- Repo: https://github.com/beava-dev/beava
- Site: https://beava.dev
- License: Apache 2.0
- Languages: Rust (server), Python (SDK)

Format follows CONTRIBUTING.md (sentence case, capital start, period end, short).

Hi @manuzhang thank you for creating this awesome lists, building something that can help people do these rolling feature engineering and realtime analytics easier hope I can get your approval !