### PR TITLE
Add Eventum to data generation platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 - [Streamdal](https://streamdal.com) [Go/Node.js/Python] - A tool to embed privacy controls in your application code to detect PII as it enters and leaves your systems, preventing it from reaching unintended data streams or pipelines.
 - [Turbine](https://github.com/Netflix/Turbine) [Java] - tool for aggregating streams of Server-Sent Event (SSE) JSON data into a single stream.
 - [Nussknacker](https://github.com/TouK/nussknacker) [Scala] - A visual tool to define and run real-time decision algorithms.
+- [Eventum](https://github.com/eventum-generator/eventum) - Data generation platform for producing synthetic event streams based on templates, scripts or log samples.
 
 ### Closed Source
 


### PR DESCRIPTION
Added Eventum to the list of data generation platforms.

## Project

[Eventum](https://github.com/eventum-generator/eventum)

Docs: https://eventum.run

## Why This Project Is Awesome

Eventum generates event streams from templates, Python scripts or by replaying log files. A web UI provides live preview and debugging. There are many outputs for generated data: Kafka, OpenSearch, ClickHouse, HTTP, TCP/UDP, files, stdout, etc.