### PR TITLE
Add CapyMOA to Online Machine Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Mesos, designed for high performance data processing jobs that require flexibili
 ### Online Machine Learning 
 
 - [Apache Samoa](https://github.com/apache/incubator-samoa) [Java] - distributed streaming machine learning (ML) framework that contains a programing abstraction for distributed streaming ML algorithms.
+- [CapyMOA](https://github.com/adaptive-machine-learning/CapyMOA) [Python] - Efficient machine learning for data streams, covering classification, regression, clustering, anomaly detection, semi-supervised learning, online continual learning and drift detection.
 - [DataSketches](https://github.com/DataSketches/sketches-core) [Java] - sketches library from Yahoo!.
 - [Numalogic] (https://github.com/numaproj/numalogic) [Python] - Collection of ML models and libraries for real-time anomaly detection and forecasting on time series data. Built on Numaflow, a K8s native stream processing platform
 - [River](https://github.com/online-ml/river) [Python] - online machine learning library.


### PR DESCRIPTION
Adds [CapyMOA](https://github.com/adaptive-machine-learning/CapyMOA), an open-source Python library for machine learning on data streams (i.e. online machine learning).

CapyMOA covers classification, regression, clustering, anomaly detection, semi-supervised learning, online continual learning and drift detection for streaming data, and it is actively developed. In some cases, it uses MOA as a backend, so it reaches near-Java throughput while presenting a Python API. 

- Docs: https://capymoa.org
- PyPI: https://pypi.org/project/capymoa/
- Paper: https://arxiv.org/abs/2502.07432
- Licence: BSD-3-Clause

Placed alphabetically between Apache Samoa and DataSketches.
