### PR TITLE
Check project status weekly and restore managed category

### DIFF
--- a/.github/workflows/project-status.yml
+++ b/.github/workflows/project-status.yml
@@ -1,0 +1,51 @@
+name: Project status
+
+on:
+  schedule:
+    # Mondays at 03:19 UTC.
+    - cron: "19 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: project-status
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check project status
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Test the project status checker
+        run: node --test scripts/check-project-status.test.mjs
+
+      - name: Check GitHub project activity
+        id: project-status
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-project-status.mjs --output project-status-report.md
+
+      - name: Upload project status report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: project-status-report
+          path: project-status-report.md
+          if-no-files-found: error
+
+      - name: Fail when the README needs review
+        if: steps.project-status.outcome == 'failure'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 - [Libraries, SDKs, and Programming Models](#libraries-sdks-and-programming-models)
 - [Data Integration and Pipelines](#data-integration-and-pipelines)
 - [Applications and Tools](#applications-and-tools)
+- [Managed and Closed Source](#managed-and-closed-source)
 - [Benchmarks](#benchmarks)
 - [Readings](#readings)
 
 ### Engines and Platforms
 
 - [Aeron](https://github.com/aeron-io/aeron) <sub>![Java/C++][language-java-cpp]</sub> - Reliable UDP unicast, multicast, and IPC message transport.
-- [Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/) - Fully managed service for ingesting and processing real-time data streams on AWS.
 - [Apache Apex](https://github.com/apache/apex-core) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Unified platform for big data stream and batch processing.
 - [Apache Flink](https://github.com/apache/flink) <sub>![Java][language-java]</sub> - Distributed engine for stateful computation over bounded and unbounded data streams.
 - [Apache Heron](https://github.com/apache/incubator-heron) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Retired distributed, fault-tolerant stream processing engine originally developed at Twitter.
@@ -33,19 +33,15 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 - [Arroyo](https://github.com/ArroyoSystems/arroyo) <sub>![Rust][language-rust]</sub> - Distributed stream processing engine for stateful SQL computations over unbounded data.
 - [AthenaX](https://github.com/uber-archive/AthenaX) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Uber's retired SQL-based streaming analytics platform.
 - [AutoMQ](https://github.com/AutoMQ/automq) <sub>![Java/Scala][language-java-scala]</sub> - Diskless Kafka-compatible streaming platform that stores durable data in object storage.
-- [Azure Stream Analytics](https://azure.microsoft.com/en-us/products/stream-analytics) <sub>![SQL][language-sql]</sub> - Fully managed service for serverless real-time analytics in the cloud and at the edge.
 - [Bytewax](https://github.com/bytewax/bytewax) <sub>![Python/Rust][language-python-rust]</sub> - Community-maintained Python framework with a Rust-based distributed engine for stateful stream processing.
-- [Concord](https://www.slideshare.net/concord-io/may-2016-data-by-the-bay-concord-simple-flexible-stream-processing-on-apache-mesos) <sub>![Archived][archived-badge]</sub> <sub>![C++][language-cpp]</sub> - Historical distributed stream processing framework built on Apache Mesos.
 - [eKuiper](https://github.com/lf-edge/ekuiper) <sub>![Go][language-go]</sub> - Lightweight data stream processing engine for resource-constrained IoT edge devices.
 - [Esper](https://github.com/espertechinc/esper) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Complex event processing, Streaming SQL, and event series analysis engine.
 - [Fluvio](https://github.com/fluvio-community/fluvio) <sub>![Rust/WASM][language-rust-wasm]</sub> - Composable, stateful data streaming system with programmable in-line computation.
 - [Gazette](https://github.com/gazette/core) <sub>![Go][language-go]</sub> - Cloud-storage-backed streaming infrastructure that combines SQL, batch, and millisecond-latency stream processing.
 - [Gearpump](https://github.com/gearpump/gearpump) <sub>![Scala][language-scala]</sub> - Lightweight real-time distributed streaming engine built on Akka.
-- [Google Cloud Dataflow](https://cloud.google.com/dataflow/) <sub>![Java/Python/Go][language-java-python-go]</sub> - Fully managed service for running Apache Beam batch and streaming pipelines.
 - [hailstorm](https://github.com/hailstorm-hs/hailstorm) <sub>![Archived][archived-badge]</sub> <sub>![Haskell][language-haskell]</sub> - Distributed stream processing with exactly-once semantics based on Storm.
 - [Hazelcast Jet](https://github.com/hazelcast/hazelcast-jet) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Stream and batch processing engine whose development moved into Hazelcast Platform.
 - [HStreamDB](https://github.com/hstreamdb/hstream) <sub>![Haskell][language-haskell]</sub> - Cloud-native streaming database for IoT data storage and real-time processing.
-- [IBM Streams](https://www.ibm.com/support/pages/ibm-streams-life-cycle-guidance) <sub>![Archived][archived-badge]</sub> <sub>![Python/Java/Scala][language-python-java-scala]</sub> - Discontinued platform for distributed stream processing and real-time analytics.
 - [ksqlDB](https://github.com/confluentinc/ksql) <sub>![Java][language-java]</sub> - Source-available database purpose-built for stream processing applications.
 - [LaminarDB](https://github.com/laminardb/laminardb) <sub>![Rust][language-rust]</sub> - Embeddable streaming SQL engine built on Apache Arrow and DataFusion.
 - [LightSaber](https://github.com/lsds/LightSaber) <sub>![Archived][archived-badge]</sub> <sub>![C++][language-cpp]</sub> - Multi-core stream processing engine using code generation for window aggregation.
@@ -100,7 +96,6 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 - [MediaPipe](https://github.com/google-ai-edge/mediapipe) <sub>![C++/Python/Java/TypeScript][language-cpp-python-java-typescript]</sub> - Cross-platform, customizable ML solutions for live and streaming media.
 - [Monix](https://github.com/monix/monix) <sub>![Scala][language-scala]</sub> - High-performance Scala and Scala.js library for asynchronous and event-based programs.
 - [Numalogic](https://github.com/numaproj/numalogic) <sub>![Python][language-python]</sub> - Collection of machine learning models and tools for anomaly detection and forecasting on operational time-series data.
-- [NVIDIA DeepStream SDK](https://developer.nvidia.com/deepstream-sdk) <sub>![C/C++/Python][language-c-cpp-python]</sub> - Open-source GStreamer-based toolkit for real-time AI streaming analytics and multi-sensor processing.
 - [Pulsar](https://github.com/quantmind/pulsar) <sub>![Archived][archived-badge]</sub> <sub>![Python][language-python]</sub> - Actor-based event-driven concurrency framework for Python.
 - [Quix Streams](https://github.com/quixio/quix-streams) <sub>![Python][language-python]</sub> - Python framework for real-time data engineering, analytics, and machine learning on Apache Kafka.
 - [River](https://github.com/online-ml/river) <sub>![Python][language-python]</sub> - Online machine learning library for Python.
@@ -151,6 +146,15 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 - [Substation](https://github.com/brexhq/substation) <sub>![Go][language-go]</sub> - Toolkit for routing, normalizing, and enriching security event and audit logs.
 - [Turbine](https://github.com/Netflix/Turbine) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Netflix tool for aggregating Server-Sent Event JSON streams.
 - [Zilla](https://github.com/aklivity/zilla) <sub>![Java][language-java]</sub> - Multi-protocol gateway for connecting applications, APIs, agents, and devices to event streams.
+
+### Managed and Closed Source
+
+- [Amazon Kinesis Data Streams](https://aws.amazon.com/kinesis/data-streams/) - Fully managed service for ingesting and processing real-time data streams on AWS.
+- [Azure Stream Analytics](https://azure.microsoft.com/en-us/products/stream-analytics) <sub>![SQL][language-sql]</sub> - Fully managed service for serverless real-time analytics in the cloud and at the edge.
+- [Concord](https://www.slideshare.net/concord-io/may-2016-data-by-the-bay-concord-simple-flexible-stream-processing-on-apache-mesos) <sub>![Archived][archived-badge]</sub> <sub>![C++][language-cpp]</sub> - Historical distributed stream processing framework built on Apache Mesos.
+- [Google Cloud Dataflow](https://cloud.google.com/dataflow/) <sub>![Java/Python/Go][language-java-python-go]</sub> - Fully managed service for running Apache Beam batch and streaming pipelines.
+- [IBM Streams](https://www.ibm.com/support/pages/ibm-streams-life-cycle-guidance) <sub>![Archived][archived-badge]</sub> <sub>![Python/Java/Scala][language-python-java-scala]</sub> - Discontinued proprietary platform for distributed stream processing and real-time analytics.
+- [NVIDIA DeepStream SDK](https://developer.nvidia.com/deepstream-sdk) <sub>![C/C++/Python][language-c-cpp-python]</sub> - GStreamer-based toolkit with open-source components and proprietary NVIDIA libraries for real-time AI streaming analytics and multi-sensor processing.
 
 ### Benchmarks
 

--- a/scripts/check-project-status.mjs
+++ b/scripts/check-project-status.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+
+import { appendFile, readFile, writeFile } from "node:fs/promises";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_INACTIVE_YEARS = 2;
+const DEFAULT_CONCURRENCY = 8;
+
+export function parseGitHubProjects(markdown) {
+  const projects = [];
+
+  for (const [index, line] of markdown.split("\n").entries()) {
+    const match = line.match(/^-\s+\[([^\]]+)\]\((https?:\/\/[^)]+)\)(.*)$/i);
+    if (!match) {
+      continue;
+    }
+
+    let url;
+    try {
+      url = new URL(match[2]);
+    } catch {
+      continue;
+    }
+
+    if (!["github.com", "www.github.com"].includes(url.hostname.toLowerCase())) {
+      continue;
+    }
+
+    const segments = url.pathname.split("/").filter(Boolean);
+    if (segments.length < 2) {
+      continue;
+    }
+
+    const owner = segments[0];
+    const repo = segments[1].replace(/\.git$/i, "");
+    projects.push({
+      name: match[1],
+      url: match[2],
+      owner,
+      repo,
+      key: `${owner}/${repo}`.toLowerCase(),
+      line: index + 1,
+      archivedBadge: /\[archived-badge\]/i.test(match[3]),
+    });
+  }
+
+  return projects;
+}
+
+export function inactivityCutoff(now = new Date(), years = DEFAULT_INACTIVE_YEARS) {
+  return new Date(
+    Date.UTC(now.getUTCFullYear() - years, now.getUTCMonth(), now.getUTCDate()),
+  );
+}
+
+export function findingsForProject(project, status, cutoff) {
+  if (status.error) {
+    return [`Could not check repository: ${status.error}`];
+  }
+
+  const findings = [];
+  const requestedName = `${project.owner}/${project.repo}`;
+
+  if (status.missing) {
+    return ["Repository is missing or inaccessible"];
+  }
+
+  if (status.fullName.toLowerCase() !== requestedName.toLowerCase()) {
+    findings.push(`Repository moved to ${status.fullName}`);
+  }
+
+  if (!project.archivedBadge) {
+    if (status.archived) {
+      findings.push("GitHub repository is archived but the README has no Archived badge");
+    } else if (status.disabled) {
+      findings.push("GitHub repository is disabled but the README has no Archived badge");
+    } else if (!status.defaultBranch) {
+      findings.push("Repository has no default branch or commits");
+    } else if (!status.lastCommitDate) {
+      findings.push("Could not determine the latest default-branch commit date");
+    } else if (new Date(status.lastCommitDate) < cutoff) {
+      findings.push(
+        `No default-branch activity for two years (last commit ${status.lastCommitDate.slice(0, 10)})`,
+      );
+    }
+  }
+
+  return findings;
+}
+
+export function formatReport({ projects, statuses, cutoff, generatedAt = new Date() }) {
+  const rows = [];
+
+  for (const project of projects) {
+    const status = statuses.get(project.key);
+    const findings = findingsForProject(project, status, cutoff);
+    if (findings.length > 0) {
+      rows.push({ project, status, findings });
+    }
+  }
+
+  const uniqueRepositories = new Set(projects.map((project) => project.key)).size;
+  const lines = [
+    "# Weekly project status report",
+    "",
+    `Generated: ${generatedAt.toISOString()}`,
+    "",
+    `Checked ${projects.length} README entries across ${uniqueRepositories} unique GitHub repositories.`,
+    `Repositories without an Archived badge are considered inactive when their latest default-branch commit predates ${cutoff.toISOString().slice(0, 10)}.`,
+    "",
+  ];
+
+  if (rows.length === 0) {
+    lines.push("✅ No project-status drift detected.", "");
+  } else {
+    lines.push(
+      `⚠️ Found ${rows.length} README ${rows.length === 1 ? "entry" : "entries"} requiring review.`,
+      "",
+      "| Project | Repository | Finding | README line |",
+      "| --- | --- | --- | ---: |",
+    );
+
+    for (const { project, status, findings } of rows) {
+      const repository = status.fullName || `${project.owner}/${project.repo}`;
+      const repositoryUrl = status.htmlUrl || project.url;
+      lines.push(
+        `| ${escapeTable(project.name)} | [${escapeTable(repository)}](${repositoryUrl}) | ${findings.map(escapeTable).join("<br>")} | ${project.line} |`,
+      );
+    }
+    lines.push("");
+  }
+
+  lines.push(
+    "> Existing Archived badges are treated as deliberate. An apparently active repository may still represent an officially discontinued project, so the workflow does not remove badges automatically.",
+    "",
+    "> Non-GitHub entries and changes to project descriptions or language badges still require human review.",
+    "",
+  );
+
+  return { markdown: lines.join("\n"), findingCount: rows.length };
+}
+
+function escapeTable(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+async function fetchJson(url, token, attempts = 3) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "awesome-streaming-project-status-check",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const response = await fetch(url, {
+      headers,
+    });
+
+    if (response.ok) {
+      return response.json();
+    }
+
+    if (response.status === 404) {
+      const error = new Error("Not Found");
+      error.status = 404;
+      throw error;
+    }
+
+    if (attempt < attempts && (response.status === 429 || response.status >= 500)) {
+      await new Promise((resolve) => setTimeout(resolve, 250 * 2 ** (attempt - 1)));
+      continue;
+    }
+
+    const detail = await response.text();
+    throw new Error(`GitHub API returned ${response.status}: ${detail.slice(0, 200)}`);
+  }
+}
+
+async function checkRepository(project, token) {
+  const apiBase = "https://api.github.com/repos";
+  const repositoryPath = `${encodeURIComponent(project.owner)}/${encodeURIComponent(project.repo)}`;
+
+  try {
+    const repository = await fetchJson(`${apiBase}/${repositoryPath}`, token);
+    let lastCommitDate = null;
+
+    if (!repository.archived && !repository.disabled && repository.default_branch) {
+      const commits = await fetchJson(
+        `${apiBase}/${repositoryPath}/commits?sha=${encodeURIComponent(repository.default_branch)}&per_page=1`,
+        token,
+      );
+      const commit = commits[0]?.commit;
+      lastCommitDate = commit?.committer?.date || commit?.author?.date || null;
+    }
+
+    return {
+      archived: repository.archived,
+      disabled: repository.disabled,
+      defaultBranch: repository.default_branch,
+      fullName: repository.full_name,
+      htmlUrl: repository.html_url,
+      lastCommitDate,
+    };
+  } catch (error) {
+    if (error.status === 404) {
+      return {
+        missing: true,
+        fullName: `${project.owner}/${project.repo}`,
+        htmlUrl: project.url,
+      };
+    }
+    return {
+      error: error.message,
+      fullName: `${project.owner}/${project.repo}`,
+      htmlUrl: project.url,
+    };
+  }
+}
+
+async function mapWithConcurrency(items, concurrency, callback) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await callback(items[index], index);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, () => worker()),
+  );
+  return results;
+}
+
+function parseArguments(argv) {
+  const options = {
+    readme: "README.md",
+    output: null,
+    inactiveYears: DEFAULT_INACTIVE_YEARS,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--readme") {
+      options.readme = argv[++index];
+    } else if (argument === "--output") {
+      options.output = argv[++index];
+    } else if (argument === "--inactive-years") {
+      options.inactiveYears = Number(argv[++index]);
+    } else if (argument === "--help") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!Number.isFinite(options.inactiveYears) || options.inactiveYears <= 0) {
+    throw new Error("--inactive-years must be a positive number");
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    console.log(
+      "Usage: node scripts/check-project-status.mjs [--readme README.md] [--output report.md] [--inactive-years 2]",
+    );
+    return;
+  }
+
+  const markdown = await readFile(options.readme, "utf8");
+  const projects = parseGitHubProjects(markdown);
+  if (projects.length === 0) {
+    throw new Error(`No GitHub project entries found in ${options.readme}`);
+  }
+
+  const uniqueProjects = [...new Map(projects.map((project) => [project.key, project])).values()];
+  const results = await mapWithConcurrency(uniqueProjects, DEFAULT_CONCURRENCY, (project) =>
+    checkRepository(project, process.env.GITHUB_TOKEN),
+  );
+  const statuses = new Map(
+    uniqueProjects.map((project, index) => [project.key, results[index]]),
+  );
+  const cutoff = inactivityCutoff(new Date(), options.inactiveYears);
+  const report = formatReport({ projects, statuses, cutoff });
+
+  console.log(report.markdown);
+  if (options.output) {
+    await writeFile(options.output, report.markdown);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, report.markdown);
+  }
+
+  if (report.findingCount > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(process.argv[1]).href : null;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    console.error(error.stack || error.message);
+    process.exitCode = 2;
+  });
+}

--- a/scripts/check-project-status.mjs
+++ b/scripts/check-project-status.mjs
@@ -81,7 +81,7 @@ export function findingsForProject(project, status, cutoff) {
       findings.push("Could not determine the latest default-branch commit date");
     } else if (new Date(status.lastCommitDate) < cutoff) {
       findings.push(
-        `No default-branch activity for two years (last commit ${status.lastCommitDate.slice(0, 10)})`,
+        `No default-branch activity since ${cutoff.toISOString().slice(0, 10)} (last commit ${status.lastCommitDate.slice(0, 10)})`,
       );
     }
   }
@@ -239,7 +239,7 @@ async function mapWithConcurrency(items, concurrency, callback) {
   return results;
 }
 
-function parseArguments(argv) {
+export function parseArguments(argv) {
   const options = {
     readme: "README.md",
     output: null,
@@ -261,8 +261,8 @@ function parseArguments(argv) {
     }
   }
 
-  if (!Number.isFinite(options.inactiveYears) || options.inactiveYears <= 0) {
-    throw new Error("--inactive-years must be a positive number");
+  if (!Number.isInteger(options.inactiveYears) || options.inactiveYears <= 0) {
+    throw new Error("--inactive-years must be a positive integer");
   }
   return options;
 }

--- a/scripts/check-project-status.test.mjs
+++ b/scripts/check-project-status.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  findingsForProject,
+  formatReport,
+  inactivityCutoff,
+  parseGitHubProjects,
+} from "./check-project-status.mjs";
+
+test("parses GitHub project entries and archived badges", () => {
+  const projects = parseGitHubProjects(`
+- [Active](https://github.com/example/active) <sub>![Go][language-go]</sub> - Active.
+- [Retired](https://github.com/example/retired) <sub>![Archived][archived-badge]</sub> - Retired.
+- [Website](https://example.com/project) - Hosted elsewhere.
+1. [Reading](https://github.com/example/article)
+`);
+
+  assert.deepEqual(
+    projects.map(({ name, key, line, archivedBadge }) => ({ name, key, line, archivedBadge })),
+    [
+      { name: "Active", key: "example/active", line: 2, archivedBadge: false },
+      { name: "Retired", key: "example/retired", line: 3, archivedBadge: true },
+    ],
+  );
+});
+
+test("uses a calendar-based two-year inactivity cutoff", () => {
+  assert.equal(
+    inactivityCutoff(new Date("2026-08-13T12:00:00Z"), 2).toISOString(),
+    "2024-08-13T00:00:00.000Z",
+  );
+});
+
+test("flags inactive unbadged projects but preserves deliberate archived badges", () => {
+  const cutoff = new Date("2024-08-13T00:00:00Z");
+  const status = {
+    archived: false,
+    disabled: false,
+    defaultBranch: "main",
+    fullName: "example/project",
+    htmlUrl: "https://github.com/example/project",
+    lastCommitDate: "2024-08-12T23:59:59Z",
+  };
+
+  assert.match(
+    findingsForProject(
+      { owner: "example", repo: "project", archivedBadge: false },
+      status,
+      cutoff,
+    )[0],
+    /No default-branch activity/,
+  );
+  assert.deepEqual(
+    findingsForProject(
+      { owner: "example", repo: "project", archivedBadge: true },
+      status,
+      cutoff,
+    ),
+    [],
+  );
+});
+
+test("reports archived, moved, and unavailable repositories", () => {
+  const cutoff = new Date("2024-08-13T00:00:00Z");
+  const projects = [
+    {
+      name: "Moved",
+      owner: "old",
+      repo: "project",
+      key: "old/project",
+      url: "https://github.com/old/project",
+      line: 10,
+      archivedBadge: false,
+    },
+    {
+      name: "Missing",
+      owner: "gone",
+      repo: "project",
+      key: "gone/project",
+      url: "https://github.com/gone/project",
+      line: 20,
+      archivedBadge: false,
+    },
+  ];
+  const statuses = new Map([
+    [
+      "old/project",
+      {
+        archived: true,
+        disabled: false,
+        defaultBranch: "main",
+        fullName: "new/project",
+        htmlUrl: "https://github.com/new/project",
+        lastCommitDate: null,
+      },
+    ],
+    [
+      "gone/project",
+      {
+        missing: true,
+        fullName: "gone/project",
+        htmlUrl: "https://github.com/gone/project",
+      },
+    ],
+  ]);
+
+  const report = formatReport({
+    projects,
+    statuses,
+    cutoff,
+    generatedAt: new Date("2026-08-13T00:00:00Z"),
+  });
+
+  assert.equal(report.findingCount, 2);
+  assert.match(report.markdown, /Repository moved to new\/project/);
+  assert.match(report.markdown, /GitHub repository is archived/);
+  assert.match(report.markdown, /Repository is missing or inaccessible/);
+});

--- a/scripts/check-project-status.test.mjs
+++ b/scripts/check-project-status.test.mjs
@@ -5,6 +5,7 @@ import {
   findingsForProject,
   formatReport,
   inactivityCutoff,
+  parseArguments,
   parseGitHubProjects,
 } from "./check-project-status.mjs";
 
@@ -32,7 +33,7 @@ test("uses a calendar-based two-year inactivity cutoff", () => {
   );
 });
 
-test("flags inactive unbadged projects but preserves deliberate archived badges", () => {
+test("reports the configured cutoff for inactive unbadged projects", () => {
   const cutoff = new Date("2024-08-13T00:00:00Z");
   const status = {
     archived: false,
@@ -43,13 +44,13 @@ test("flags inactive unbadged projects but preserves deliberate archived badges"
     lastCommitDate: "2024-08-12T23:59:59Z",
   };
 
-  assert.match(
+  assert.equal(
     findingsForProject(
       { owner: "example", repo: "project", archivedBadge: false },
       status,
       cutoff,
     )[0],
-    /No default-branch activity/,
+    "No default-branch activity since 2024-08-13 (last commit 2024-08-12)",
   );
   assert.deepEqual(
     findingsForProject(
@@ -58,6 +59,18 @@ test("flags inactive unbadged projects but preserves deliberate archived badges"
       cutoff,
     ),
     [],
+  );
+});
+
+test("accepts only positive whole-year inactivity intervals", () => {
+  assert.equal(parseArguments(["--inactive-years", "1"]).inactiveYears, 1);
+  assert.throws(
+    () => parseArguments(["--inactive-years", "0.5"]),
+    /must be a positive integer/,
+  );
+  assert.throws(
+    () => parseArguments(["--inactive-years", "0"]),
+    /must be a positive integer/,
   );
 });
 


### PR DESCRIPTION
## Summary
- add a weekly and manually runnable project-status workflow
- check GitHub-backed README entries for repository moves, missing repositories, archive/disabled state, and two-year default-branch inactivity
- publish findings in the job summary and as a downloadable Markdown artifact without editing the README automatically
- restore the `Managed and Closed Source` category for managed services, proprietary products, and mixed-source SDKs
- clarify that NVIDIA DeepStream combines open-source components with proprietary NVIDIA libraries

## Validation
- `node --check scripts/check-project-status.mjs`
- `node --test scripts/check-project-status.test.mjs`
- parsed `.github/workflows/project-status.yml` with Ruby YAML
- `git diff --check`
- verified 128 unique projects, alphabetized within all seven categories
- completed an end-to-end live GitHub API check against Apache Flink