### PR TITLE
add yasdb to Data Integrations and Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A curated list of awesome [streaming (stream processing)](http://radar.oreilly.c
 - [Redpanda Connect](https://github.com/redpanda-data/connect) <sub>![Go][language-go]</sub> - Declarative stream processor for moving, enriching, transforming, and filtering data between sources and sinks.
 - [RudderStack](https://github.com/rudderlabs/rudder-server) <sub>![Go][language-go]</sub> - Developer-focused customer data platform for event streaming and cloud-to-warehouse data pipelines.
 - [Suro](https://github.com/Netflix/suro) <sub>![Archived][archived-badge]</sub> <sub>![Java][language-java]</sub> - Netflix data pipeline for collecting, aggregating, and dispatching application events.
+- [yasdb](https://github.com/JayJamieson/yasdb) <sub>![Go][language-go]</sub> - Durable Streams protocol server backed by SlateDB object storage, with offset-based catch-up reads and SSE or long-poll tailing.
 
 ### Applications and Tools
 


### PR DESCRIPTION
[yasdb](https://github.com/JayJamieson/yasdb) is a [Durable Streams](https://github.com/durable-streams/durable-streams/blob/main/PROTOCOL.md) protocol server written in Go. Streams are addressable append-only logs served over plain HTTP: clients read from any offset and tail live over SSE or long-poll, so they resume exactly where they left off across reconnects, refreshes and devices.

Durability comes from [SlateDB](https://slatedb.io), an LSM engine that uses only object storage. yasdb runs against a local file store, S3/R2/Tigris, or in-memory for development, as a single `net/http` binary with no broker or coordinator.

## Proposed entry

Appended to the end of Data Integration and Pipelines, after `Suro`:

```markdown
- [yasdb](https://github.com/JayJamieson/yasdb) <sub>![Go][language-go]</sub> - Durable Streams protocol server backed by SlateDB object storage, with offset-based catch-up reads and SSE or long-poll tailing.
```

On section choice, I put yasdb under Data Integration and Pipelines, but Engines and
Platforms is arguably the better home since that section holds the other object-storage-backed
logs, AutoMQ and Gazette. Happy to move the entry if you prefer.

## Why it should be included

- Fills a gap in the list. The list covers object-storage-backed logs (AutoMQ, Gazette)
  and server-to-server log transports, but nothing here implements Durable Streams. Durable
  Streams is an HTTP-native durable log protocol aimed at client applications rather than
  backend services. The distinction is the read path: a plain cacheable HTTP GET, not a
  broker-specific client protocol.
- Correctness is tested, not asserted. Maelstrom/Jepsen log-consistency checks
  (including a crash-injection variant over the live-read and cache paths) and a fuzz
  property test asserting cache bytes equal store bytes.
- Tuning decisions are backed by measurements. `BENCHMARKS.md` documents the numbers
  behind the defaults, including where the sweep was inconclusive and why.
- Operable. Prometheus endpoint exposing native SlateDB engine metrics, a starter
  Grafana dashboard, an admin stream-listing endpoint, and a Fly.io + Tigris deploy guide.
- MIT licensed, CI on GitHub Actions, golangci-lint configured.

## Checklist

- [x] Searched existing entries, no Durable Streams server is currently listed.
- [x] Single suggestion in this pull request.
- [x] Format matches the surrounding entries: `[name](link) <sub>![Lang][language-x]</sub> - Description.`
- [x] Description starts with a capital and ends with a period.
- [x] No trailing whitespace.

Disclosure: I'm the author of yasdb.
